### PR TITLE
Feat/get data params

### DIFF
--- a/src/lib/db/db.querybuilder.ts
+++ b/src/lib/db/db.querybuilder.ts
@@ -1,0 +1,73 @@
+import { Json } from "./db.rawtypes";
+import { SupabaseClient } from "@supabase/supabase-js";
+
+function isStringRecord(obj: any): obj is Record<string, unknown> {
+  return obj && typeof obj === "object" && !Array.isArray(obj);
+}
+
+/**
+ *
+ * @param supabase The instance of a Supabase client to interact with
+ * @param tableName The name of the table to query
+ * @param params JSON parameters to filter the query
+ * @returns
+ */
+export function buildSelectQuery(
+  supabase: SupabaseClient,
+  tableName: string,
+  params: Json
+): any {
+  let query = supabase.from(tableName).select();
+
+  if (isStringRecord(params)) {
+    /**
+     *  Handle general filtering.
+     *  params["filters"] is expected to be an array of parameters to .filter()
+     *  by, following the ff. format:
+     *  filters: [
+     *    [column, operator, value],
+     *    ...
+     *    [columnN, operatorN, valueN]
+     *  ]
+     *  e.g.,
+     *  filters: [
+     *    ["status", "eq", "active"]
+     *    ["age", "gte", 123]
+     *  ]
+     * See {@link https://supabase.com/docs/reference/javascript/filter} for a
+     * list of supported filter operators.
+     */
+    if (Array.isArray(params["filters"])) {
+      for (const filter of params["filters"]) {
+        if (Array.isArray(filter)) {
+          const column = filter[0] as string;
+          const operator = filter[1] as string;
+          const value = filter[2];
+          query = query.filter(column, operator, value);
+        }
+      }
+    }
+
+    /**
+     * Add more cases as needed. The above technically encompasses
+     * all that's needed, but it might be convenient to handle the more
+     * specific database query builder functions, too, like:
+     */
+
+    /**
+     * Handle "eq" key for equality filters (object of column-value pairs), e.g.
+     *  eq: {
+     *    name: "John",
+     *    age: 30,
+     *  },
+     */
+    const { eq } = params;
+    if (isStringRecord(eq)) {
+      for (const column of Object.keys(eq)) {
+        query = query.eq(column, eq[column]);
+      }
+    }
+  }
+
+  return query;
+}

--- a/src/lib/db/db.querybuilder.ts
+++ b/src/lib/db/db.querybuilder.ts
@@ -20,85 +20,52 @@ export function buildSelectQuery(
   let query = supabase.from(tableName).select();
 
   if (isStringRecord(params)) {
-    /**
-     *  Handle general filtering.
-     *  params["filters"] is expected to be an array of parameters to .filter()
-     *  by, following the ff. format:
-     *  filters: [
-     *    [column, operator, value],
-     *    ...
-     *    [columnN, operatorN, valueN]
-     *  ]
-     *  e.g.,
-     *  filters: [
-     *    ["status", "eq", "active"]
-     *    ["age", "gte", 123]
-     *  ]
-     * See {@link https://supabase.com/docs/reference/javascript/filter} for a
-     * list of supported filter operators.
-     */
-    if (Array.isArray(params["filters"])) {
-      for (const filter of params["filters"]) {
-        if (Array.isArray(filter)) {
-          const column = filter[0] as string;
-          const operator = filter[1] as string;
-          const value = filter[2];
-          query = query.filter(column, operator, value);
+    const operatorList = [
+      "eq", "neq", "gt", "gte", "lt", "lte", "like", "ilike", "is", "in",
+      "contains", "containedBy", "rangeGt", "rangeGte", "match", "overlaps",
+      "textSearch",
+
+      // Special handling required
+      "or", "not", "filter", "order"
+    ];
+
+    for (const operator of operatorList) {
+      const value = params[operator];
+      if ((operator === "or" || operator === "order") && value !== undefined) {
+        // 'or' expects raw PostgREST syntax, 'order' expects a column name
+        // ! This does not account for ordering options like ascending/descending (.reverse() can do that)
+        query = query.or(value as string);
+      } else if ((operator === "not" || operator === "filter") && value !== undefined) {
+        /**
+         *  'filter' and 'not' expect a list of lists of filters, e.g.
+         *   filter: [
+         *    ["status", "eq", "active"],
+         *    ["age", "gte", 123]
+         *  ]
+         *  */
+        if (Array.isArray(params[operator])) {
+          for (const filter of params[operator]) {
+            if (Array.isArray(filter)) {
+              const column = filter[0] as string;
+              const operator = filter[1] as string;
+              const value = filter[2];
+              // @ts-ignore: dynamic method call
+              query = query[operator](column, operator, value);
+            }
+          }
         }
-      }
-    }
-
-    /**
-     * Add more cases as needed. The above technically encompasses
-     * all that's needed, but it might be convenient to handle the more
-     * specific database query builder functions, too.
-     */
-    const operatorMap: Record<string, string> = {
-      eq: "eq",
-      neq: "neq",
-      gt: "gt",
-      gte: "gte",
-      lt: "lt",
-      lte: "lte",
-      like: "like",
-      ilike: "ilike", // case insensitive like
-      is: "is",
-      in: "in",
-      contains: "contains",
-      containedBy: "containedBy",
-      rangeGt: "rangeGt",
-      rangeGte: "rangeGte",
-      match: "match",
-      overlaps: "overlaps",
-    };
-
-    /**
-     * If your params object contains an operation
-     * 
-     * operation: {
-     *    column: value,
-     *    column2: value2,
-     * }
-     * 
-     * then it essentailly gets mapped into
-     * 
-     * query = query.operation(column, value).operation(column2, value2)
-     * 
-     * Note that some operations like `or`, `order`, `textSearch`, and `not`
-     * are handled differently, as they do not take a column-value pair
-     * 
-     */
-    for (const [paramKey, methodName] of Object.entries(operatorMap)) {
-      const value = params[paramKey];
-      if (isStringRecord(value)) { //
+      } else if (isStringRecord(value)) {
+        // General handling: query = query.operator(column, value[column]);
+        /**
+         * ! Supabase docs allow textSearch to be used with additional options,
+         * ! but this is not handled here
+         *  */
         for (const column of Object.keys(value)) {
           // @ts-ignore: dynamic method call
-          query = query[methodName](column, value[column]);
+          query = query[operator](column, value[column]);
         }
       }
     }
-
-
   }
 
   return query;

--- a/src/lib/db/db.querybuilder.ts
+++ b/src/lib/db/db.querybuilder.ts
@@ -51,22 +51,54 @@ export function buildSelectQuery(
     /**
      * Add more cases as needed. The above technically encompasses
      * all that's needed, but it might be convenient to handle the more
-     * specific database query builder functions, too, like:
+     * specific database query builder functions, too.
      */
+    const operatorMap: Record<string, string> = {
+      eq: "eq",
+      neq: "neq",
+      gt: "gt",
+      gte: "gte",
+      lt: "lt",
+      lte: "lte",
+      like: "like",
+      ilike: "ilike", // case insensitive like
+      is: "is",
+      in: "in",
+      contains: "contains",
+      containedBy: "containedBy",
+      rangeGt: "rangeGt",
+      rangeGte: "rangeGte",
+      match: "match",
+      overlaps: "overlaps",
+    };
 
     /**
-     * Handle "eq" key for equality filters (object of column-value pairs), e.g.
-     *  eq: {
-     *    name: "John",
-     *    age: 30,
-     *  },
+     * If your params object contains an operation
+     * 
+     * operation: {
+     *    column: value,
+     *    column2: value2,
+     * }
+     * 
+     * then it essentailly gets mapped into
+     * 
+     * query = query.operation(column, value).operation(column2, value2)
+     * 
+     * Note that some operations like `or`, `order`, `textSearch`, and `not`
+     * are handled differently, as they do not take a column-value pair
+     * 
      */
-    const { eq } = params;
-    if (isStringRecord(eq)) {
-      for (const column of Object.keys(eq)) {
-        query = query.eq(column, eq[column]);
+    for (const [paramKey, methodName] of Object.entries(operatorMap)) {
+      const value = params[paramKey];
+      if (isStringRecord(value)) { //
+        for (const column of Object.keys(value)) {
+          // @ts-ignore: dynamic method call
+          query = query[methodName](column, value[column]);
+        }
       }
     }
+
+
   }
 
   return query;


### PR DESCRIPTION
Parameterizes the `getData` function in `createTableHook` via a query builder.

Parameters on a created table hook `tableHook` should be set through `tableHook.setParams(params)`, with `params` as a `Json` object in the ff. general format:
{
  operator: {column: value}
}
For most operators, additional column-value pairs can be specified; this leads to the operator being applied for each pair.

Certain operators (or, not, filter, order) require a different format, see the comments for these cases.